### PR TITLE
Finalize minimal Raiziom demo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+COPY backend ./backend
+COPY plugins ./plugins
+CMD ["uvicorn", "backend/app/main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # RaiziomFix
 
-AI Plugin Marketplace
+A minimal AI plugin marketplace demo with FastAPI backend and React frontend.
+
+## Backend
+
+```bash
+cd backend
+pip install -r ../requirements.txt
+uvicorn app.main:app --reload
+```
+
+## Frontend
+
+```bash
+cd frontend
+npm install
+npm start
+```
+
+The backend exposes simple authentication endpoints (`/register`, `/login`), plugin listing at `/plugins`, idea handling via `/idea`, and a toy AI endpoint `/ai/respond`.
+
+Use the token returned from `/login` in the `token` query parameter for authenticated routes.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,89 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Depends
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+from passlib.context import CryptContext
+from uuid import uuid4
+from typing import Dict, List
+import os
+import json
+
 app = FastAPI()
-@app.get('/')
+
+# Allow frontend connections
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+# In-memory stores
+users: Dict[str, str] = {}
+tokens: Dict[str, str] = {}
+
+class UserCredentials(BaseModel):
+    email: str
+    password: str
+
+class Idea(BaseModel):
+    idea: str
+
+class AIInput(BaseModel):
+    input: str
+
+@app.get("/")
 def read_root():
-    return {'message': 'RaiziomFix API'}
+    return {"message": "RaiziomFix API"}
+
+@app.post("/register")
+def register(creds: UserCredentials):
+    if creds.email in users:
+        raise HTTPException(status_code=400, detail="User already exists")
+    users[creds.email] = pwd_context.hash(creds.password)
+    return {"status": "registered"}
+
+@app.post("/login")
+def login(creds: UserCredentials):
+    stored = users.get(creds.email)
+    if not stored or not pwd_context.verify(creds.password, stored):
+        raise HTTPException(status_code=401, detail="Invalid credentials")
+    token = str(uuid4())
+    tokens[token] = creds.email
+    return {"token": token}
+
+# Dependency to check token
+def get_current_user(token: str | None = None):
+    if not token or token not in tokens:
+        raise HTTPException(status_code=401, detail="Invalid token")
+    return tokens[token]
+
+@app.get("/plugins")
+def list_plugins(user: str = Depends(get_current_user)):
+    plugins_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "plugins")
+    results: List[Dict] = []
+    if os.path.isdir(plugins_path):
+        for name in os.listdir(plugins_path):
+            f = os.path.join(plugins_path, name, "plugin.json")
+            if os.path.isfile(f):
+                with open(f) as fp:
+                    try:
+                        results.append(json.load(fp))
+                    except json.JSONDecodeError:
+                        continue
+    return results
+
+@app.post("/idea")
+def send_idea(idea: Idea, user: str = Depends(get_current_user)):
+    # Simple echo for now
+    return {"received": idea.idea}
+
+@app.post("/ai/respond")
+def ai_respond(inp: AIInput, user: str = Depends(get_current_user)):
+    text = inp.input
+    # Naive AI: reverse the text
+    reply = text[::-1]
+    return {"reply": reply}
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+pip install -r requirements.txt
+uvicorn backend/app/main:app --host 0.0.0.0 --port 8000

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -5,7 +5,7 @@ import Login from "./pages/Login";
 import RaiziomAssistant from "./components/RaiziomAssistant";
 
 function PrivateRoute({ children }) {
-  const loggedIn = localStorage.getItem("raiziomUser");
+  const loggedIn = localStorage.getItem("raiziomToken");
   return loggedIn ? children : <Navigate to="/login" />;
 }
 

--- a/frontend/src/api/raiziom.js
+++ b/frontend/src/api/raiziom.js
@@ -1,10 +1,42 @@
-const BASE_URL = "https://raiziomfix.onrender.com"; // replace with actual
+const BASE_URL = ""; // relative to same domain
 
-export async function sendIdeaToRaiziom(idea) {
-  const res = await fetch(`${BASE_URL}/idea`, {
+export async function register(email, password) {
+  const res = await fetch(`${BASE_URL}/register`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ idea }),
+    body: JSON.stringify({ email, password })
   });
+  return res.json();
+}
+
+export async function login(email, password) {
+  const res = await fetch(`${BASE_URL}/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password })
+  });
+  return res.json();
+}
+
+export async function sendIdeaToRaiziom(idea, token) {
+  const res = await fetch(`${BASE_URL}/idea?token=${token}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ idea })
+  });
+  return res.json();
+}
+
+export async function askAI(message, token) {
+  const res = await fetch(`${BASE_URL}/ai/respond?token=${token}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ input: message })
+  });
+  return res.json();
+}
+
+export async function getPlugins(token) {
+  const res = await fetch(`${BASE_URL}/plugins?token=${token}`);
   return res.json();
 }

--- a/frontend/src/components/RaiziomAssistant.js
+++ b/frontend/src/components/RaiziomAssistant.js
@@ -1,30 +1,24 @@
 import React, { useState } from 'react';
+import { askAI } from '../api/raiziom';
 
 export default function RaiziomAssistant() {
-  const [message, setMessage] = useState("");
-  const [response, setResponse] = useState("");
+  const [message, setMessage] = useState('');
+  const [response, setResponse] = useState('');
 
   const askRaiziom = async () => {
-    const res = await fetch("https://raiziomfix.onrender.com/ai/respond", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({ input: message }),
-    });
-
-    const data = await res.json();
-    setResponse(data.reply);
+    const token = localStorage.getItem('raiziomToken');
+    if (!token) {
+      alert('Login required');
+      return;
+    }
+    const data = await askAI(message, token);
+    if (data.reply) setResponse(data.reply);
   };
 
   return (
-    <div style={{ position: "fixed", bottom: 20, right: 20, background: "#fff", padding: 20 }}>
+    <div style={{ position: 'fixed', bottom: 20, right: 20, background: '#fff', padding: 20 }}>
       <h3>Raiziom</h3>
-      <input
-        value={message}
-        onChange={(e) => setMessage(e.target.value)}
-        placeholder="Ask"
-      />
+      <input value={message} onChange={(e) => setMessage(e.target.value)} placeholder="Ask" />
       <button onClick={askRaiziom}>Send</button>
       <div>{response}</div>
     </div>

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,4 +1,24 @@
-// Dashboard.js
+import { useEffect, useState } from "react";
+import { getPlugins } from "../api/raiziom";
+
 export default function Dashboard() {
-  return <h1>Welcome to Raiziom Dashboard</h1>;
+  const [plugins, setPlugins] = useState([]);
+
+  useEffect(() => {
+    const token = localStorage.getItem("raiziomToken");
+    if (!token) return;
+    getPlugins(token).then(setPlugins);
+  }, []);
+
+  return (
+    <div style={{ padding: "1rem" }}>
+      <h1>Raiziom Dashboard</h1>
+      <h3>Available Plugins</h3>
+      <ul>
+        {plugins.map((p, i) => (
+          <li key={i}>{p.name} - v{p.version}</li>
+        ))}
+      </ul>
+    </div>
+  );
 }

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,30 +1,46 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { login, register } from "../api/raiziom";
 
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [isRegister, setIsRegister] = useState(false);
   const navigate = useNavigate();
 
-  const handleLogin = (e) => {
+  const handleSubmit = async (e) => {
     e.preventDefault();
-    if (email === "admin@raiziom.com" && password === "1234") {
-      localStorage.setItem("raiziomUser", email);
-      navigate("/");
-    } else {
-      alert("Invalid credentials");
+    try {
+      if (isRegister) {
+        await register(email, password);
+        alert("Registered. Please log in.");
+        setIsRegister(false);
+        return;
+      }
+      const data = await login(email, password);
+      if (data.token) {
+        localStorage.setItem("raiziomToken", data.token);
+        navigate("/");
+      } else {
+        alert("Login failed");
+      }
+    } catch (err) {
+      alert("Error");
     }
   };
 
   return (
     <div style={{ padding: "2rem" }}>
-      <h2>Raiziom Login</h2>
-      <form onSubmit={handleLogin}>
-        <input value={email} onChange={e => setEmail(e.target.value)} placeholder="Email" />
+      <h2>{isRegister ? "Register" : "Raiziom Login"}</h2>
+      <form onSubmit={handleSubmit}>
+        <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="Email" />
         <br />
-        <input type="password" value={password} onChange={e => setPassword(e.target.value)} placeholder="Password" />
+        <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="Password" />
         <br />
-        <button type="submit">Login</button>
+        <button type="submit">{isRegister ? "Register" : "Login"}</button>
+        <button type="button" onClick={() => setIsRegister(!isRegister)} style={{ marginLeft: 8 }}>
+          {isRegister ? "Go to Login" : "Need an account?"}
+        </button>
       </form>
     </div>
   );

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -1,4 +1,12 @@
-// Settings.js
 export default function Settings() {
-  return <h1>Raiziom Settings</h1>;
+  const logout = () => {
+    localStorage.removeItem("raiziomToken");
+    window.location.href = "/login";
+  };
+  return (
+    <div style={{ padding: "1rem" }}>
+      <h1>Settings</h1>
+      <button onClick={logout}>Logout</button>
+    </div>
+  );
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 python-dotenv
 httpx
+passlib[bcrypt]


### PR DESCRIPTION
## Summary
- flesh out FastAPI app with registration, login and token auth
- add endpoints for plugins, idea handling and AI response
- integrate frontend with new API
- add simple dashboard with plugin list and logout screen
- provide Dockerfile and deploy script for running backend
- update README instructions

## Testing
- `python -m py_compile backend/app/main.py`
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6883b5104b648324ad26cc4e6411cf45