### PR TITLE
Enable basic credit wallet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
 # RaiziomFix
 
 AI Plugin Marketplace
+
+## Credit Based System
+
+The backend includes a very small in-memory wallet implementation. New users
+receive trial credits when they sign up. Credits are deducted for every agent
+action via the `/action` endpoint. Users can inspect their wallet balance and
+transaction logs using `/wallet/{email}` and `/earnings/{email}`.
+
+Funds can be added using `/add_funds` with a payment provider of `paystack` or
+`stripe`. If environment variables `PAYSTACK_KEY` or `STRIPE_KEY` are not
+supplied the payment call is mocked but credits are still granted, making the
+system usable without real payment keys.
+
+### Running Locally
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload --port 8000 --app-dir backend/app
+```
+
+### Example Usage
+
+```bash
+# sign up
+curl -X POST http://localhost:8000/signup -H 'Content-Type: application/json' \
+  -d '{"email":"user@example.com","password":"pass"}'
+
+# perform an action costing credits
+curl -X POST http://localhost:8000/action -H 'Content-Type: application/json' \
+  -d '{"email":"user@example.com","action":"run-agent"}'
+
+# add more credits (mocked if keys are missing)
+curl -X POST http://localhost:8000/add_funds -H 'Content-Type: application/json' \
+  -d '{"email":"user@example.com","amount":5,"provider":"paystack"}'
+
+# view wallet balance
+curl http://localhost:8000/wallet/user@example.com
+```

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,90 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from typing import List
+from .models import User, Transaction
+from .payment import pay_with_paystack, pay_with_stripe
+import os
+
 app = FastAPI()
+
+# Simple in-memory user store
+users = {}
+FREE_CREDITS = 10
+COST_PER_ACTION = 1
+
+class SignUp(BaseModel):
+    email: str
+    password: str
+
+class Login(BaseModel):
+    email: str
+    password: str
+
+class Action(BaseModel):
+    email: str
+    action: str
+
+class AddFunds(BaseModel):
+    email: str
+    amount: int
+    provider: str = "mock"
+
 @app.get('/')
 def read_root():
     return {'message': 'RaiziomFix API'}
+
+@app.post('/signup')
+def signup(data: SignUp):
+    if data.email in users:
+        raise HTTPException(status_code=400, detail='User exists')
+    user = User(email=data.email, password=data.password, credits=FREE_CREDITS)
+    user.logs.append(Transaction(amount=FREE_CREDITS, description='Free trial credits'))
+    users[data.email] = user
+    return {'message': 'signed up', 'credits': user.credits}
+
+@app.post('/login')
+def login(data: Login):
+    user = users.get(data.email)
+    if not user or user.password != data.password:
+        raise HTTPException(status_code=400, detail='Invalid credentials')
+    return {'message': 'logged in'}
+
+@app.get('/wallet/{email}')
+def wallet(email: str):
+    user = users.get(email)
+    if not user:
+        raise HTTPException(status_code=404, detail='Not found')
+    return {'credits': user.credits}
+
+@app.get('/earnings/{email}')
+def earnings(email: str):
+    user = users.get(email)
+    if not user:
+        raise HTTPException(status_code=404, detail='Not found')
+    return {'logs': [t.__dict__ for t in user.logs]}
+
+@app.post('/action')
+def do_action(data: Action):
+    user = users.get(data.email)
+    if not user:
+        raise HTTPException(status_code=404, detail='Not found')
+    if user.credits < COST_PER_ACTION:
+        raise HTTPException(status_code=400, detail='Insufficient credits')
+    user.credits -= COST_PER_ACTION
+    user.logs.append(Transaction(amount=-COST_PER_ACTION, description=data.action))
+    return {'credits': user.credits}
+
+@app.post('/add_funds')
+def add_funds(data: AddFunds):
+    user = users.get(data.email)
+    if not user:
+        raise HTTPException(status_code=404, detail='Not found')
+    # Payment integration stub
+    if data.provider.lower() == 'paystack':
+        pay_with_paystack(data.amount, data.email)
+    elif data.provider.lower() == 'stripe':
+        pay_with_stripe(data.amount, data.email)
+    # For now we just credit the wallet
+    user.credits += data.amount
+    user.logs.append(Transaction(amount=data.amount, description=f'Added via {data.provider}'))
+    return {'credits': user.credits}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass, field
+from typing import List
+import datetime
+
+@dataclass
+class Transaction:
+    amount: int
+    description: str
+    timestamp: datetime.datetime = field(default_factory=datetime.datetime.utcnow)
+
+@dataclass
+class User:
+    email: str
+    password: str
+    credits: int = 0
+    logs: List[Transaction] = field(default_factory=list)

--- a/backend/app/payment.py
+++ b/backend/app/payment.py
@@ -1,0 +1,25 @@
+import os
+from paystackapi.paystack import Paystack
+import stripe as stripe_lib
+
+PAYSTACK_KEY = os.getenv('PAYSTACK_KEY')
+STRIPE_KEY = os.getenv('STRIPE_KEY')
+
+
+def pay_with_paystack(amount: int, email: str):
+    """Mocked Paystack payment."""
+    if not PAYSTACK_KEY:
+        # No key, return mock response
+        return {"status": "mock", "reference": "mock-paystack"}
+    paystack = Paystack(secret_key=PAYSTACK_KEY)
+    # Real integration would go here
+    return {"status": "success", "reference": "paystack-ref"}
+
+
+def pay_with_stripe(amount: int, email: str):
+    """Mocked Stripe charge."""
+    if not STRIPE_KEY:
+        return {"status": "mock", "reference": "mock-stripe"}
+    stripe_lib.api_key = STRIPE_KEY
+    # Real charge logic would go here
+    return {"status": "success", "reference": "stripe-ref"}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,6 +1,7 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import Dashboard from "./pages/Dashboard";
 import Settings from "./pages/Settings";
+import Wallet from "./pages/Wallet";
 import Login from "./pages/Login";
 import RaiziomAssistant from "./components/RaiziomAssistant";
 
@@ -16,6 +17,7 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/" element={<PrivateRoute><Dashboard /></PrivateRoute>} />
         <Route path="/settings" element={<PrivateRoute><Settings /></PrivateRoute>} />
+        <Route path="/wallet" element={<PrivateRoute><Wallet /></PrivateRoute>} />
       </Routes>
       <RaiziomAssistant />
     </Router>

--- a/frontend/src/api/raiziom.js
+++ b/frontend/src/api/raiziom.js
@@ -8,3 +8,49 @@ export async function sendIdeaToRaiziom(idea) {
   });
   return res.json();
 }
+
+export async function signup(email, password) {
+  const res = await fetch(`${BASE_URL}/signup`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+  return res.json();
+}
+
+export async function login(email, password) {
+  const res = await fetch(`${BASE_URL}/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, password }),
+  });
+  return res.json();
+}
+
+export async function getWallet(email) {
+  const res = await fetch(`${BASE_URL}/wallet/${email}`);
+  return res.json();
+}
+
+export async function recordAction(email, action) {
+  const res = await fetch(`${BASE_URL}/action`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, action }),
+  });
+  return res.json();
+}
+
+export async function addFunds(email, amount, provider = "mock") {
+  const res = await fetch(`${BASE_URL}/add_funds`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, amount, provider }),
+  });
+  return res.json();
+}
+
+export async function getEarnings(email) {
+  const res = await fetch(`${BASE_URL}/earnings/${email}`);
+  return res.json();
+}

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,4 +1,27 @@
 // Dashboard.js
+import { useEffect } from "react";
+import { recordAction, getWallet } from "../api/raiziom";
+import { useState } from "react";
+import { Link } from "react-router-dom";
+
 export default function Dashboard() {
-  return <h1>Welcome to Raiziom Dashboard</h1>;
+  const email = localStorage.getItem("raiziomUser");
+  const [credits, setCredits] = useState(0);
+
+  useEffect(() => {
+    async function fetchCredits() {
+      const w = await getWallet(email);
+      setCredits(w.credits || 0);
+    }
+    fetchCredits();
+    recordAction(email, "dashboard-view");
+  }, [email]);
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h1>Welcome to Raiziom Dashboard</h1>
+      <p>Credits: {credits}</p>
+      <Link to="/wallet">Go to Wallet</Link>
+    </div>
+  );
 }

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,19 +1,21 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { login as apiLogin, signup } from "../api/raiziom";
 
 export default function Login() {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const navigate = useNavigate();
 
-  const handleLogin = (e) => {
+  const handleLogin = async (e) => {
     e.preventDefault();
-    if (email === "admin@raiziom.com" && password === "1234") {
-      localStorage.setItem("raiziomUser", email);
-      navigate("/");
-    } else {
-      alert("Invalid credentials");
+    try {
+      await apiLogin(email, password);
+    } catch (err) {
+      await signup(email, password);
     }
+    localStorage.setItem("raiziomUser", email);
+    navigate("/");
   };
 
   return (

--- a/frontend/src/pages/Wallet.js
+++ b/frontend/src/pages/Wallet.js
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { getWallet, getEarnings, addFunds } from "../api/raiziom";
+
+export default function Wallet() {
+  const email = localStorage.getItem("raiziomUser");
+  const [credits, setCredits] = useState(0);
+  const [logs, setLogs] = useState([]);
+
+  useEffect(() => {
+    async function fetchData() {
+      const wallet = await getWallet(email);
+      setCredits(wallet.credits || 0);
+      const e = await getEarnings(email);
+      setLogs(e.logs || []);
+    }
+    fetchData();
+  }, [email]);
+
+  const handleAdd = async () => {
+    await addFunds(email, 5, "paystack");
+    const wallet = await getWallet(email);
+    setCredits(wallet.credits || 0);
+  };
+
+  return (
+    <div style={{ padding: "2rem" }}>
+      <h2>Wallet</h2>
+      <p>Credits: {credits}</p>
+      <button onClick={handleAdd}>Add 5 Credits</button>
+      <h3>Logs</h3>
+      <ul>
+        {logs.map((l, i) => (
+          <li key={i}>{l.description}: {l.amount}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ fastapi
 uvicorn[standard]
 python-dotenv
 httpx
+stripe
+paystackapi


### PR DESCRIPTION
## Summary
- build a wallet with credits for each user
- stub payment providers Paystack and Stripe
- add simple wallet API and React wallet page
- show wallet credits in the dashboard
- document the credit system

## Testing
- `pip check`
- `npm test --prefix frontend`

------
https://chatgpt.com/codex/tasks/task_e_6883b95fa0b083248708aab5a0366f01