### PR TITLE
Add Stripe checkout integration

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,8 @@
 # Stripe
 STRIPE_SECRET_KEY=sk_test_placeholder
 STRIPE_PUBLIC_KEY=pk_test_placeholder
+STRIPE_PRICE_ID=price_placeholder
+FRONTEND_URL=http://localhost:3000
 
 # Coinbase Commerce
 COINBASE_API_KEY=coinbase_placeholder

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
 # RaiziomFix
 
 AI Plugin Marketplace
+
+## Payments
+
+The project includes a simple Stripe integration to create checkout sessions for
+purchasing credits. Configure the following environment variables in your `.env`
+file:
+
+```
+STRIPE_SECRET_KEY=sk_test_your_key
+STRIPE_PUBLIC_KEY=pk_test_your_key
+STRIPE_PRICE_ID=price_id_from_stripe
+FRONTEND_URL=http://localhost:3000
+```
+
+Run the backend with these variables and the dashboard will provide a **Buy
+Credits** button that redirects to Stripe Checkout.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,43 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from dotenv import load_dotenv
+import os
+import stripe
+
+load_dotenv()
+
+stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
+
 app = FastAPI()
-@app.get('/')
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/")
 def read_root():
-    return {'message': 'RaiziomFix API'}
+    return {"message": "RaiziomFix API"}
+
+
+@app.post("/create-checkout-session")
+def create_checkout_session():
+    try:
+        session = stripe.checkout.Session.create(
+            payment_method_types=["card"],
+            line_items=[
+                {
+                    "price": os.getenv("STRIPE_PRICE_ID"),
+                    "quantity": 1,
+                }
+            ],
+            mode="payment",
+            success_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/?success=true",
+            cancel_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/?canceled=true",
+        )
+        return {"url": session.url}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/frontend/src/api/raiziom.js
+++ b/frontend/src/api/raiziom.js
@@ -8,3 +8,10 @@ export async function sendIdeaToRaiziom(idea) {
   });
   return res.json();
 }
+
+export async function createCheckoutSession() {
+  const res = await fetch(`${BASE_URL}/create-checkout-session`, {
+    method: "POST",
+  });
+  return res.json();
+}

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,4 +1,17 @@
-// Dashboard.js
+import { createCheckoutSession } from "../api/raiziom";
+
 export default function Dashboard() {
-  return <h1>Welcome to Raiziom Dashboard</h1>;
+  const buyCredits = async () => {
+    const data = await createCheckoutSession();
+    if (data.url) {
+      window.location.href = data.url;
+    }
+  };
+
+  return (
+    <div>
+      <h1>Welcome to Raiziom Dashboard</h1>
+      <button onClick={buyCredits}>Buy Credits</button>
+    </div>
+  );
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn[standard]
 python-dotenv
 httpx
+stripe


### PR DESCRIPTION
## Summary
- add Stripe requirements and environment variables
- integrate Stripe Checkout in FastAPI backend
- expose endpoint to create checkout session
- enable CORS
- add API helper and button in frontend dashboard
- document new payment setup

## Testing
- `npm test --prefix frontend --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6883b8cb098c8324ba5e88c077bb75c4