### PR TITLE
Stabilize Raiziomfix core

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,15 @@
-
-# Use official Python image as base
+# 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 FROM python:3.11-slim AS backend
-
 WORKDIR /app
-
-# Install backend dependencies
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-
-# Copy backend code
 COPY backend ./backend
 
-# Build frontend
 FROM node:18 AS frontend
 WORKDIR /frontend
 COPY frontend ./frontend
 RUN cd frontend && npm install && npm run build
 
-# Production image
 FROM python:3.11-slim
 WORKDIR /app
 COPY --from=backend /usr/local/lib/python3.11/site-packages /usr/local/lib/python3.11/site-packages
@@ -28,11 +20,5 @@ COPY requirements.txt .
 ENV PORT=8000
 EXPOSE 8000
 
+# 🧠 Core logic: part of Raiziom engine
 CMD ["uvicorn", "backend.app.main:app", "--host", "0.0.0.0", "--port", "8000"]
-FROM python:3.11-slim
-WORKDIR /app
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-COPY backend ./backend
-COPY plugins ./plugins
-CMD ["uvicorn", "backend/app/main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,151 +1,23 @@
+# 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 
-from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
-from typing import List
-from .models import User, Transaction
-from .payment import pay_with_paystack, pay_with_stripe
-import os
-
-app = FastAPI()
-
-# Simple in-memory user store
-users = {}
-FREE_CREDITS = 10
-COST_PER_ACTION = 1
-
-class SignUp(BaseModel):
-    email: str
-    password: str
-
-class Login(BaseModel):
-    email: str
-    password: str
-
-class Action(BaseModel):
-    email: str
-    action: str
-
-class AddFunds(BaseModel):
-    email: str
-    amount: int
-    provider: str = "mock"
-
-from fastapi import FastAPI
-from pydantic import BaseModel
-from dotenv import load_dotenv
-import os
-from pathlib import Path
-
-# Load environment variables from .env if present
-load_dotenv(Path(__file__).resolve().parents[2] / '.env')
-
-API_BASE = os.getenv('API_BASE', 'https://api.example.com')
-SECRET_KEY = os.getenv('SECRET_KEY', 'change-me')
-
-app = FastAPI()
-
-class Idea(BaseModel):
-    idea: str
-
-class Message(BaseModel):
-    input: str
-
-@app.get('/')
-def read_root():
-    return {'message': 'RaiziomFix API'}
-
-@app.post('/signup')
-def signup(data: SignUp):
-    if data.email in users:
-        raise HTTPException(status_code=400, detail='User exists')
-    user = User(email=data.email, password=data.password, credits=FREE_CREDITS)
-    user.logs.append(Transaction(amount=FREE_CREDITS, description='Free trial credits'))
-    users[data.email] = user
-    return {'message': 'signed up', 'credits': user.credits}
-
-@app.post('/login')
-def login(data: Login):
-    user = users.get(data.email)
-    if not user or user.password != data.password:
-        raise HTTPException(status_code=400, detail='Invalid credentials')
-    return {'message': 'logged in'}
-
-@app.get('/wallet/{email}')
-def wallet(email: str):
-    user = users.get(email)
-    if not user:
-        raise HTTPException(status_code=404, detail='Not found')
-    return {'credits': user.credits}
-
-@app.get('/earnings/{email}')
-def earnings(email: str):
-    user = users.get(email)
-    if not user:
-        raise HTTPException(status_code=404, detail='Not found')
-    return {'logs': [t.__dict__ for t in user.logs]}
-
-@app.post('/action')
-def do_action(data: Action):
-    user = users.get(data.email)
-    if not user:
-        raise HTTPException(status_code=404, detail='Not found')
-    if user.credits < COST_PER_ACTION:
-        raise HTTPException(status_code=400, detail='Insufficient credits')
-    user.credits -= COST_PER_ACTION
-    user.logs.append(Transaction(amount=-COST_PER_ACTION, description=data.action))
-    return {'credits': user.credits}
-
-@app.post('/add_funds')
-def add_funds(data: AddFunds):
-    user = users.get(data.email)
-    if not user:
-        raise HTTPException(status_code=404, detail='Not found')
-    # Payment integration stub
-    if data.provider.lower() == 'paystack':
-        pay_with_paystack(data.amount, data.email)
-    elif data.provider.lower() == 'stripe':
-        pay_with_stripe(data.amount, data.email)
-    # For now we just credit the wallet
-    user.credits += data.amount
-    user.logs.append(Transaction(amount=data.amount, description=f'Added via {data.provider}'))
-    return {'credits': user.credits}
-@app.post('/idea')
-def receive_idea(idea: Idea):
-    # Placeholder for storing idea or forwarding to a service
-    return {'received': idea.idea}
-
-@app.post('/ai/respond')
-def ai_respond(message: Message):
-    reply = f"Echo from {API_BASE}: {message.input}"
-    return {'reply': reply}
-
-from fastapi import FastAPI, HTTPException
-from fastapi.middleware.cors import CORSMiddleware
-from dotenv import load_dotenv
-import os
-import stripe
-
-load_dotenv()
-
-stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
-
-app = FastAPI()
-
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
 from fastapi import FastAPI, HTTPException, Depends
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from passlib.context import CryptContext
 from uuid import uuid4
 from typing import Dict, List
+from pathlib import Path
 import os
 import json
+from dotenv import load_dotenv
+
+from .models import User, Transaction
+from .payment import pay_with_paystack, pay_with_stripe
+
+# Load environment variables
+load_dotenv(Path(__file__).resolve().parents[2] / '.env')
 
 app = FastAPI()
-
-# Allow frontend connections
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -159,10 +31,23 @@ pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 # In-memory stores
 users: Dict[str, str] = {}
 tokens: Dict[str, str] = {}
+wallets: Dict[str, User] = {}
+
+FREE_CREDITS = 10
+COST_PER_ACTION = 1
 
 class UserCredentials(BaseModel):
     email: str
     password: str
+
+class Action(BaseModel):
+    email: str
+    action: str
+
+class AddFunds(BaseModel):
+    email: str
+    amount: int
+    provider: str = "mock"
 
 class Idea(BaseModel):
     idea: str
@@ -174,32 +59,21 @@ class AIInput(BaseModel):
 def read_root():
     return {"message": "RaiziomFix API"}
 
-
-@app.post("/create-checkout-session")
-def create_checkout_session():
-    try:
-        session = stripe.checkout.Session.create(
-            payment_method_types=["card"],
-            line_items=[
-                {
-                    "price": os.getenv("STRIPE_PRICE_ID"),
-                    "quantity": 1,
-                }
-            ],
-            mode="payment",
-            success_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/?success=true",
-            cancel_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/?canceled=true",
-        )
-        return {"url": session.url}
-    except Exception as e:
-        raise HTTPException(status_code=400, detail=str(e))
+# 🧠 Core logic: part of Raiziom engine
 @app.post("/register")
 def register(creds: UserCredentials):
     if creds.email in users:
         raise HTTPException(status_code=400, detail="User already exists")
     users[creds.email] = pwd_context.hash(creds.password)
+    wallets[creds.email] = User(email=creds.email, password=creds.password, credits=FREE_CREDITS)
+    wallets[creds.email].logs.append(Transaction(amount=FREE_CREDITS, description="Free trial credits"))
     return {"status": "registered"}
 
+@app.post("/signup")
+def signup(creds: UserCredentials):
+    return register(creds)
+
+# 🧠 Core logic: part of Raiziom engine
 @app.post("/login")
 def login(creds: UserCredentials):
     stored = users.get(creds.email)
@@ -215,9 +89,64 @@ def get_current_user(token: str | None = None):
         raise HTTPException(status_code=401, detail="Invalid token")
     return tokens[token]
 
+@app.get("/wallet/{email}")
+def wallet(email: str):
+    user = wallets.get(email)
+    if not user:
+        raise HTTPException(status_code=404, detail="Not found")
+    return {"credits": user.credits}
+
+@app.get("/earnings/{email}")
+def earnings(email: str):
+    user = wallets.get(email)
+    if not user:
+        raise HTTPException(status_code=404, detail="Not found")
+    return {"logs": [t.__dict__ for t in user.logs]}
+
+@app.post("/action")
+def do_action(data: Action):
+    user = wallets.get(data.email)
+    if not user:
+        raise HTTPException(status_code=404, detail="Not found")
+    if user.credits < COST_PER_ACTION:
+        raise HTTPException(status_code=400, detail="Insufficient credits")
+    user.credits -= COST_PER_ACTION
+    user.logs.append(Transaction(amount=-COST_PER_ACTION, description=data.action))
+    return {"credits": user.credits}
+
+@app.post("/add_funds")
+def add_funds(data: AddFunds):
+    user = wallets.get(data.email)
+    if not user:
+        raise HTTPException(status_code=404, detail="Not found")
+    if data.provider.lower() == "paystack":
+        pay_with_paystack(data.amount, data.email)
+    elif data.provider.lower() == "stripe":
+        pay_with_stripe(data.amount, data.email)
+    user.credits += data.amount
+    user.logs.append(Transaction(amount=data.amount, description=f"Added via {data.provider}"))
+    return {"credits": user.credits}
+
+# 🧠 Core logic: part of Raiziom engine
+@app.post("/create-checkout-session")
+def create_checkout_session():
+    try:
+        import stripe
+        stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
+        session = stripe.checkout.Session.create(
+            payment_method_types=["card"],
+            line_items=[{"price": os.getenv("STRIPE_PRICE_ID"), "quantity": 1}],
+            mode="payment",
+            success_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/?success=true",
+            cancel_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/?canceled=true",
+        )
+        return {"url": session.url}
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
 @app.get("/plugins")
-def list_plugins(user: str = Depends(get_current_user)):
-    plugins_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "plugins")
+def list_plugins(token: str = Depends(get_current_user)):
+    plugins_path = os.path.join(Path(__file__).resolve().parents[1], "plugins")
     results: List[Dict] = []
     if os.path.isdir(plugins_path):
         for name in os.listdir(plugins_path):
@@ -231,14 +160,11 @@ def list_plugins(user: str = Depends(get_current_user)):
     return results
 
 @app.post("/idea")
-def send_idea(idea: Idea, user: str = Depends(get_current_user)):
-    # Simple echo for now
+def send_idea(idea: Idea, token: str = Depends(get_current_user)):
     return {"received": idea.idea}
 
 @app.post("/ai/respond")
-def ai_respond(inp: AIInput, user: str = Depends(get_current_user)):
+def ai_respond(inp: AIInput, token: str = Depends(get_current_user)):
     text = inp.input
-    # Naive AI: reverse the text
     reply = text[::-1]
     return {"reply": reply}
-

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,6 +1,9 @@
+# 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
+
 from dataclasses import dataclass, field
 from typing import List
 import datetime
+# 🧠 Core logic: part of Raiziom engine
 
 @dataclass
 class Transaction:

--- a/backend/app/payment.py
+++ b/backend/app/payment.py
@@ -1,3 +1,5 @@
+# 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
+
 import os
 from paystackapi.paystack import Paystack
 import stripe as stripe_lib
@@ -5,6 +7,7 @@ import stripe as stripe_lib
 PAYSTACK_KEY = os.getenv('PAYSTACK_KEY')
 STRIPE_KEY = os.getenv('STRIPE_KEY')
 
+# 🧠 Core logic: part of Raiziom engine
 
 def pay_with_paystack(amount: int, email: str):
     """Mocked Paystack payment."""
@@ -16,6 +19,7 @@ def pay_with_paystack(amount: int, email: str):
     return {"status": "success", "reference": "paystack-ref"}
 
 
+# 🧠 Core logic: part of Raiziom engine
 def pay_with_stripe(amount: int, email: str):
     """Mocked Stripe charge."""
     if not STRIPE_KEY:

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -1,4 +1,7 @@
+# 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
+
 from setuptools import setup, find_packages
+# 🧠 Core logic: part of Raiziom engine
 
 setup(
     name='raiziomfix-backend',

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,23 +1,13 @@
-
 #!/bin/bash
+# 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 set -e
 
-# Load environment variables if .env exists
+# Load environment variables if present
 if [ -f .env ]; then
   export $(grep -v '^#' .env | xargs)
 fi
 
-# Start backend
-uvicorn backend.app.main:app --host 0.0.0.0 --port ${PORT:-8000} &
-BACKEND_PID=$!
-
-# Build frontend
-cd frontend
-npm install
-npm run build
-cd ..
-
-wait $BACKEND_PID
-#!/bin/sh
+# 🧠 Core logic: part of Raiziom engine
 pip install -r requirements.txt
-uvicorn backend/app/main:app --host 0.0.0.0 --port 8000
+cd frontend && npm install && npm run build && cd ..
+uvicorn backend.app.main:app --host 0.0.0.0 --port ${PORT:-8000}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,3 +1,4 @@
+// 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 import { BrowserRouter as Router, Routes, Route, Navigate } from "react-router-dom";
 import Dashboard from "./pages/Dashboard";
 import Settings from "./pages/Settings";
@@ -5,6 +6,7 @@ import Wallet from "./pages/Wallet";
 import Login from "./pages/Login";
 import RaiziomAssistant from "./components/RaiziomAssistant";
 
+// 🧠 Core logic: part of Raiziom engine
 function PrivateRoute({ children }) {
   const loggedIn = localStorage.getItem("raiziomToken");
   return loggedIn ? children : <Navigate to="/login" />;

--- a/frontend/src/api/raiziom.js
+++ b/frontend/src/api/raiziom.js
@@ -1,6 +1,8 @@
+// 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 const BASE_URL = ""; // relative to same domain
 
 export async function register(email, password) {
+  // 🧠 Core logic: part of Raiziom engine
   const res = await fetch(`${BASE_URL}/register`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
@@ -9,27 +11,20 @@ export async function register(email, password) {
   return res.json();
 }
 
-export async function signup(email, password) {
-  const res = await fetch(`${BASE_URL}/signup`, {
+export const signup = register;
+
+export async function login(email, password) {
+  const res = await fetch(`${BASE_URL}/login`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email, password }),
+    body: JSON.stringify({ email, password })
   });
   return res.json();
 }
 
 export async function createCheckoutSession() {
   const res = await fetch(`${BASE_URL}/create-checkout-session`, {
-    method: "POST",
-  });
-  return res.json();
-}
-export async function login(email, password) {
-  const res = await fetch(`${BASE_URL}/login`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email, password }),
-    body: JSON.stringify({ email, password })
+    method: "POST"
   });
   return res.json();
 }
@@ -39,11 +34,29 @@ export async function getWallet(email) {
   return res.json();
 }
 
+export async function getEarnings(email) {
+  const res = await fetch(`${BASE_URL}/earnings/${email}`);
+  return res.json();
+}
+
+export async function addFunds(email, amount, provider = "mock") {
+  const res = await fetch(`${BASE_URL}/add_funds`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ email, amount, provider })
+  });
+  return res.json();
+}
+
 export async function recordAction(email, action) {
   const res = await fetch(`${BASE_URL}/action`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email, action }),
+    body: JSON.stringify({ email, action })
+  });
+  return res.json();
+}
+
 export async function sendIdeaToRaiziom(idea, token) {
   const res = await fetch(`${BASE_URL}/idea?token=${token}`, {
     method: "POST",
@@ -53,11 +66,6 @@ export async function sendIdeaToRaiziom(idea, token) {
   return res.json();
 }
 
-export async function addFunds(email, amount, provider = "mock") {
-  const res = await fetch(`${BASE_URL}/add_funds`, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ email, amount, provider }),
 export async function askAI(message, token) {
   const res = await fetch(`${BASE_URL}/ai/respond?token=${token}`, {
     method: "POST",
@@ -67,8 +75,6 @@ export async function askAI(message, token) {
   return res.json();
 }
 
-export async function getEarnings(email) {
-  const res = await fetch(`${BASE_URL}/earnings/${email}`);
 export async function getPlugins(token) {
   const res = await fetch(`${BASE_URL}/plugins?token=${token}`);
   return res.json();

--- a/frontend/src/components/RaiziomAssistant.js
+++ b/frontend/src/components/RaiziomAssistant.js
@@ -1,7 +1,9 @@
+// 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 import React, { useState } from 'react';
 import { askAI } from '../api/raiziom';
 
 export default function RaiziomAssistant() {
+// 🧠 Core logic: part of Raiziom engine
   const [message, setMessage] = useState('');
   const [response, setResponse] = useState('');
 

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,8 @@
+// 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 
+// 🧠 Core logic: part of Raiziom engine
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(<App />);

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -1,61 +1,42 @@
-
-// Dashboard.js
-import { useEffect } from "react";
-import { recordAction, getWallet } from "../api/raiziom";
-import { useState } from "react";
-import { Link } from "react-router-dom";
-
-export default function Dashboard() {
-  const email = localStorage.getItem("raiziomUser");
-  const [credits, setCredits] = useState(0);
-
-  useEffect(() => {
-    async function fetchCredits() {
-      const w = await getWallet(email);
-      setCredits(w.credits || 0);
-    }
-    fetchCredits();
-    recordAction(email, "dashboard-view");
-  }, [email]);
-
-  return (
-    <div style={{ padding: "2rem" }}>
-      <h1>Welcome to Raiziom Dashboard</h1>
-      <p>Credits: {credits}</p>
-      <Link to="/wallet">Go to Wallet</Link>
-
-import { createCheckoutSession } from "../api/raiziom";
-
-export default function Dashboard() {
-  const buyCredits = async () => {
-    const data = await createCheckoutSession();
-    if (data.url) {
-      window.location.href = data.url;
-    }
-  };
-
-  return (
-    <div>
-      <h1>Welcome to Raiziom Dashboard</h1>
-      <button onClick={buyCredits}>Buy Credits</button>
-    </div>
-  );
-}
+// 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 import { useEffect, useState } from "react";
-import { getPlugins } from "../api/raiziom";
+import { Link } from "react-router-dom";
+import { recordAction, getWallet, createCheckoutSession, getPlugins } from "../api/raiziom";
 
 export default function Dashboard() {
+  // 🧠 Core logic: part of Raiziom engine
+  const email = localStorage.getItem("raiziomUser");
+  const token = localStorage.getItem("raiziomToken");
+  const [credits, setCredits] = useState(0);
   const [plugins, setPlugins] = useState([]);
 
   useEffect(() => {
-    const token = localStorage.getItem("raiziomToken");
-    if (!token) return;
-    getPlugins(token).then(setPlugins);
-  }, []);
+    async function fetchData() {
+      if (email) {
+        const w = await getWallet(email);
+        setCredits(w.credits || 0);
+        recordAction(email, "dashboard-view");
+      }
+      if (token) {
+        const list = await getPlugins(token);
+        setPlugins(list);
+      }
+    }
+    fetchData();
+  }, [email, token]);
+
+  const buyCredits = async () => {
+    const data = await createCheckoutSession();
+    if (data.url) window.location.href = data.url;
+  };
 
   return (
     <div style={{ padding: "1rem" }}>
       <h1>Raiziom Dashboard</h1>
+      <p>Credits: {credits}</p>
+      <button onClick={buyCredits}>Buy Credits</button>
+      <br />
+      <Link to="/wallet">Go to Wallet</Link>
       <h3>Available Plugins</h3>
       <ul>
         {plugins.map((p, i) => (

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -1,20 +1,15 @@
+// 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { login as apiLogin, signup } from "../api/raiziom";
 import { login, register } from "../api/raiziom";
 
 export default function Login() {
+  // 🧠 Core logic: part of Raiziom engine
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [isRegister, setIsRegister] = useState(false);
   const navigate = useNavigate();
 
-  const handleLogin = async (e) => {
-    e.preventDefault();
-    try {
-      await apiLogin(email, password);
-    } catch (err) {
-      await signup(email, password);
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
@@ -27,15 +22,14 @@ export default function Login() {
       const data = await login(email, password);
       if (data.token) {
         localStorage.setItem("raiziomToken", data.token);
+        localStorage.setItem("raiziomUser", email);
         navigate("/");
-      } else {
-        alert("Login failed");
+        return;
       }
+      alert("Login failed");
     } catch (err) {
       alert("Error");
     }
-    localStorage.setItem("raiziomUser", email);
-    navigate("/");
   };
 
   return (

--- a/frontend/src/pages/Settings.js
+++ b/frontend/src/pages/Settings.js
@@ -1,4 +1,6 @@
+// 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 export default function Settings() {
+// 🧠 Core logic: part of Raiziom engine
   const logout = () => {
     localStorage.removeItem("raiziomToken");
     window.location.href = "/login";

--- a/frontend/src/pages/Wallet.js
+++ b/frontend/src/pages/Wallet.js
@@ -1,7 +1,9 @@
+// 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 import { useEffect, useState } from "react";
 import { getWallet, getEarnings, addFunds } from "../api/raiziom";
 
 export default function Wallet() {
+// 🧠 Core logic: part of Raiziom engine
   const email = localStorage.getItem("raiziomUser");
   const [credits, setCredits] = useState(0);
   const [logs, setLogs] = useState([]);

--- a/frontend/src/utils/raiziomMemory.js
+++ b/frontend/src/utils/raiziomMemory.js
@@ -1,6 +1,8 @@
+// 🌱 Raiziomfix Core Engine – To be evolved into Raiziom
 export const cloneMemory = {};
 
 export function updateMemory(clone, topic, value) {
+// 🧠 Core logic: part of Raiziom engine
   if (!cloneMemory[clone]) cloneMemory[clone] = {};
   if (!cloneMemory[clone][topic]) cloneMemory[clone][topic] = 0;
 


### PR DESCRIPTION
## Summary
- clean up FastAPI backend and provide token-based auth
- add simple payment stubs and plugin listing
- fix frontend routes and API helpers
- rebuild dashboard/login/wallet logic
- add Raiziom core headers throughout

## Testing
- `npm install && npm run build`
- `python -m uvicorn backend.app.main:app --port 8000 --reload`

------
https://chatgpt.com/codex/tasks/task_e_6889ed3d822083248d499bd702fe34fa